### PR TITLE
Add QTMIcon Import to fix No Known Class Method error

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -9,6 +9,7 @@
 #import "../YouTubeHeader/YTMainAppVideoPlayerOverlayView.h"
 #import "../YouTubeHeader/YTMainAppControlsOverlayView.h"
 #import "../YouTubeHeader/YTPlayerViewController.h"
+#import "../YouTubeHeader/QTMIcon.h"
 
 #define TweakKey @"YouLoop"
 #define IS_ENABLED(k) [[NSUserDefaults standardUserDefaults] boolForKey:k]


### PR DESCRIPTION
Fixes error during build in upstream project (see https://github.com/YTLitePlus/YTLitePlus/issues/514#)

Repeat of #3 (branch was deleted), see my [comment](https://github.com/bhackel/YouLoop/pull/3#issuecomment-2614413615).